### PR TITLE
Update api.js

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -595,13 +595,12 @@ function getLogFiles(callback) {
         callback(error, logs);
     });
 }
+
 if(config.api.ssl == true)
 {
   var options = {
       key: fs.readFileSync(config.poolServer.sslkey),
       cert: fs.readFileSync(config.poolServer.sslcert),
-      ca: fs.readFileSync(config.poolServer.sslca),
-      honorCipherOrder: true
   };
 
   var server2 = https.createServer(options, function(request, response){


### PR DESCRIPTION
#5 adjusts the SSL Api for the Pool. So certificates are called from the correct paths.